### PR TITLE
Suppress Sonar warning about com.sun packages

### DIFF
--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/NewStringWithoutCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/NewStringWithoutCharset.java
@@ -43,6 +43,7 @@ import com.sun.tools.javac.code.Type;
     category = JDK,
     severity = ERROR,
     maturity = MATURE)
+@SuppressWarnings("squid:S1191")
 public class NewStringWithoutCharset
     extends BugChecker
     implements NewClassTreeMatcher {


### PR DESCRIPTION
They're unavoidable since Google Error Prone uses the compiler API.
