### PR TITLE
Fixed OutputStreamWriterWithoutCharsetTest method names

### DIFF
--- a/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/OutputStreamWriterWithoutCharsetTest.java
+++ b/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/OutputStreamWriterWithoutCharsetTest.java
@@ -35,12 +35,12 @@ public class OutputStreamWriterWithoutCharsetTest {
   }
 
   @Test
-  public void newStringPositiveCases() {
+  public void outputStreamWriterWithoutCharsetPositiveCases() {
     compilationHelper.addSourceFile("OutputStreamWriterWithoutCharsetPositiveCases.java").doTest();
   }
 
   @Test
-  public void newStringNegativeCases() {
+  public void outputStreamWriterWithoutCharsetNegativeCases() {
     compilationHelper.addSourceFile("OutputStreamWriterWithoutCharsetNegativeCases.java").doTest();
   }
 }


### PR DESCRIPTION
Cut and paste error.
