### PR TITLE
Removed SuppressWarnings of Sonar com.sun rule

### DIFF
--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/FileWriterLacksCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/FileWriterLacksCharset.java
@@ -44,7 +44,6 @@ import java.io.FileWriter;
     category = JDK,
     severity = ERROR,
     maturity = MATURE)
-@SuppressWarnings("squid:S1191")
 public class FileWriterLacksCharset
     extends BugChecker
     implements NewClassTreeMatcher {

--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/GetBytesWithoutCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/GetBytesWithoutCharset.java
@@ -44,7 +44,6 @@ import com.sun.source.tree.MethodInvocationTree;
     category = JDK,
     severity = ERROR,
     maturity = MATURE)
-@SuppressWarnings("squid:S1191")
 public class GetBytesWithoutCharset
     extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/NewStringWithoutCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/NewStringWithoutCharset.java
@@ -49,7 +49,6 @@ import com.sun.tools.javac.code.Type;
     category = JDK,
     severity = ERROR,
     maturity = MATURE)
-@SuppressWarnings("squid:S1191")
 public class NewStringWithoutCharset
     extends BugChecker
     implements NewClassTreeMatcher {

--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/OutputStreamWriterWithoutCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/OutputStreamWriterWithoutCharset.java
@@ -44,7 +44,6 @@ import java.io.OutputStreamWriter;
     category = JDK,
     severity = ERROR,
     maturity = MATURE)
-@SuppressWarnings("squid:S1191")
 public class OutputStreamWriterWithoutCharset
     extends BugChecker
     implements NewClassTreeMatcher {


### PR DESCRIPTION
The Sonar plugin doesn't support SuppressWarnings on import statements. The workaround is to mark the issues as "Won't Fix"; marking issues as "Won't Fix" doesn't effect the tech debt until the next time analysis is ran.
