### PR TITLE
Cache Sonar dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jdk:
 cache:
   directories:
     - ~/.m2
+    - ~/.sonar
 
 script: .travis/build.sh
 


### PR DESCRIPTION
Speed up builds and reduce noise in logs.
