### PR TITLE
Added check for Charset.forName with standard value

### DIFF
--- a/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/CharsetForStandardCharset.java
+++ b/require-charset/src/main/java/com/github/gantsign/errorprone/require/charset/CharsetForStandardCharset.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 GantSign Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.gantsign.errorprone.require.charset;
+
+import static com.google.common.collect.Maps.immutableEntry;
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.MaturityLevel.MATURE;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.fixes.SuggestedFix.replace;
+import static com.google.errorprone.matchers.Matchers.methodInvocation;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toMap;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map.Entry;
+
+/**
+ * Bug checker to detect usage of {@link Charset#forName(String)} that can be replaced with
+ * {@link StandardCharsets}.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "CharsetForStandardCharset",
+    summary =
+        "Must use java.nio.charset.StandardCharsets where possible.",
+    category = JDK,
+    severity = ERROR,
+    maturity = MATURE)
+public class CharsetForStandardCharset
+    extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final String STANDARD_CHARSETS = StandardCharsets.class.getName();
+  private static final String CHARSET = Charset.class.getName();
+  private static final String STRING = String.class.getName();
+
+  private static final Matcher<ExpressionTree> method = methodInvocation(
+      staticMethod().onClass(CHARSET).named("forName").withParameters(STRING));
+
+  private static final ImmutableMap<Charset, String> STANDARD_CHARSET_FIELD_MAP =
+      ImmutableMap.<Charset, String>builder()
+          .put(StandardCharsets.US_ASCII, "US_ASCII")
+          .put(StandardCharsets.ISO_8859_1, "ISO_8859_1")
+          .put(StandardCharsets.UTF_8, "UTF_8")
+          .put(StandardCharsets.UTF_16BE, "UTF_16BE")
+          .put(StandardCharsets.UTF_16LE, "UTF_16LE")
+          .put(StandardCharsets.UTF_16, "UTF_16")
+          .build();
+
+  private static final ImmutableMap<String, Charset> STANDARD_CHARSET_MAP =
+      STANDARD_CHARSET_FIELD_MAP.keySet()
+          .stream()
+          .map(charset ->
+              ImmutableMap.<String, Charset>builder()
+                  .put(charset.name(), charset)
+                  .putAll(
+                      charset.aliases()
+                          .stream()
+                          .collect(toMap(identity(), alias -> charset)))
+                  .build())
+          .map(ImmutableMap::entrySet)
+          .flatMap(ImmutableSet::stream)
+          .map(entry -> immutableEntry(entry.getKey().toLowerCase(), entry.getValue()))
+          .collect(collectingAndThen(toMap(Entry::getKey, Entry::getValue), ImmutableMap::copyOf));
+
+  private boolean isStandardCharset(String name) {
+    return STANDARD_CHARSET_MAP.containsKey(requireNonNull(name).toLowerCase());
+  }
+
+  private String fieldNameForCharset(String name) {
+    Charset charset = STANDARD_CHARSET_MAP.get(requireNonNull(name).toLowerCase());
+    return STANDARD_CHARSET_FIELD_MAP.get(requireNonNull(charset));
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!method.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    ExpressionTree name = tree.getArguments().get(0);
+    if (!(name instanceof LiteralTree)) {
+      return Description.NO_MATCH;
+    }
+
+    LiteralTree literal = (LiteralTree) name;
+    String value = (String) literal.getValue();
+    if (!isStandardCharset(value)) {
+      return Description.NO_MATCH;
+    }
+
+    Description.Builder builder = buildDescription(tree);
+
+    String fieldName = requireNonNull(fieldNameForCharset(value));
+
+    String suggestion = format("%s.%s", STANDARD_CHARSETS, fieldName);
+    builder.addFix(replace(tree, suggestion));
+    return builder.build();
+  }
+
+}

--- a/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/CharsetForStandardCharsetTest.java
+++ b/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/CharsetForStandardCharsetTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 GantSign Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.gantsign.errorprone.require.charset;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link CharsetForStandardCharset}.
+ */
+@RunWith(JUnit4.class)
+public class CharsetForStandardCharsetTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(CharsetForStandardCharset.class, getClass());
+  }
+
+  @Test
+  public void charsetForStandardCharsetPositiveCases() {
+    compilationHelper.addSourceFile("CharsetForStandardCharsetPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void charsetForStandardCharsetNegativeCases() {
+    compilationHelper.addSourceFile("CharsetForStandardCharsetNegativeCases.java").doTest();
+  }
+}

--- a/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/testdata/CharsetForStandardCharsetNegativeCases.java
+++ b/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/testdata/CharsetForStandardCharsetNegativeCases.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 GantSign Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.gantsign.errorprone.require.charset.testdata;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+@SuppressWarnings("unused")
+public class CharsetForStandardCharsetNegativeCases {
+
+  Charset WINDOWS_1252 = Charset.forName("windows-1252");
+
+  Charset UTF_8 = Charset.forName(StandardCharsets.UTF_8.name());
+}

--- a/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/testdata/CharsetForStandardCharsetPositiveCases.java
+++ b/require-charset/src/test/java/com/github/gantsign/errorprone/require/charset/testdata/CharsetForStandardCharsetPositiveCases.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 GantSign Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.gantsign.errorprone.require.charset.testdata;
+
+import java.nio.charset.Charset;
+
+@SuppressWarnings("unused")
+public interface CharsetForStandardCharsetPositiveCases {
+
+  // BUG: Diagnostic contains: Did you mean 'Charset US_ASCII = java.nio.charset.StandardCharsets.US_ASCII
+  Charset US_ASCII = Charset.forName("US-ASCII");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset ISO_8859_1 = java.nio.charset.StandardCharsets.ISO_8859_1
+  Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset UTF_8 = java.nio.charset.StandardCharsets.UTF_8
+  Charset UTF_8 = Charset.forName("UTF-8");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset UTF_16BE = java.nio.charset.StandardCharsets.UTF_16BE
+  Charset UTF_16BE = Charset.forName("UTF-16BE");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset UTF_16LE = java.nio.charset.StandardCharsets.UTF_16LE
+  Charset UTF_16LE = Charset.forName("UTF-16LE");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset UTF_16 = java.nio.charset.StandardCharsets.UTF_16
+  Charset UTF_16 = Charset.forName("UTF-16");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset LATIN1 = java.nio.charset.StandardCharsets.ISO_8859_1
+  Charset LATIN1 = Charset.forName("latin1");
+
+  // BUG: Diagnostic contains: Did you mean 'Charset UTF8 = java.nio.charset.StandardCharsets.UTF_8
+  Charset UTF8 = Charset.forName("utf8");
+}


### PR DESCRIPTION
Since `java.nio.charset.StandardCharsets` defines constants for common charsets those should be used in preference of `Charset.forName()`.
