### PR TITLE
Fail build if there are jdeps warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,22 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jdeps-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jdkinternals</goal>
+              <goal>test-jdkinternals</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Catch potential Java 9 issues early.
